### PR TITLE
fix-spaces: allow queries on column names with spaces

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT/Apache-2.0"
 name = "tiberius"
 readme = "README.md"
 repository = "https://github.com/prisma/tiberius"
-version = "0.12.2"
+version = "0.12.3"
 
 [workspace]
 members = ["runtimes-macro"]

--- a/src/client.rs
+++ b/src/client.rs
@@ -28,6 +28,7 @@ use enumflags2::BitFlags;
 use futures_util::io::{AsyncRead, AsyncWrite};
 use futures_util::stream::TryStreamExt;
 use std::{borrow::Cow, fmt::Debug};
+use tracing::info;
 
 /// `Client` is the main entry point to the SQL Server, providing query
 /// execution capabilities.
@@ -331,10 +332,17 @@ impl<S: AsyncRead + AsyncWrite + Unpin + Send> Client<S> {
             .into_iter()
             .filter(|column| column.base.flags.contains(ColumnFlag::Updateable))
             .collect();
+        let col_specs_indexed = columns
+            .iter()
+            .enumerate()
+            .map(|(i, c)| format!("#{i}: {}", c))  // uses Display -> "[Name] <type>"
+            .join(", ");
 
         self.connection.flush_stream().await?;
         let col_data = columns.iter().map(|c| format!("{}", c)).join(", ");
         let query = format!("INSERT BULK {} ({})", table, col_data);
+        info!("INSERT BULK header: {}", query);
+        info!("INSERT BULK specs:  {}", col_specs_indexed);
 
         let req = BatchRequest::new(query, self.connection.context().transaction_descriptor());
         let id = self.connection.context_mut().next_packet_id();

--- a/src/client.rs
+++ b/src/client.rs
@@ -28,7 +28,6 @@ use enumflags2::BitFlags;
 use futures_util::io::{AsyncRead, AsyncWrite};
 use futures_util::stream::TryStreamExt;
 use std::{borrow::Cow, fmt::Debug};
-use tracing::info;
 
 /// `Client` is the main entry point to the SQL Server, providing query
 /// execution capabilities.
@@ -332,17 +331,10 @@ impl<S: AsyncRead + AsyncWrite + Unpin + Send> Client<S> {
             .into_iter()
             .filter(|column| column.base.flags.contains(ColumnFlag::Updateable))
             .collect();
-        let col_specs_indexed = columns
-            .iter()
-            .enumerate()
-            .map(|(i, c)| format!("#{i}: {}", c))  // uses Display -> "[Name] <type>"
-            .join(", ");
 
         self.connection.flush_stream().await?;
         let col_data = columns.iter().map(|c| format!("{}", c)).join(", ");
         let query = format!("INSERT BULK {} ({})", table, col_data);
-        info!("INSERT BULK header: {}", query);
-        info!("INSERT BULK specs:  {}", col_specs_indexed);
 
         let req = BatchRequest::new(query, self.connection.context().transaction_descriptor());
         let id = self.connection.context_mut().next_packet_id();

--- a/src/tds/codec/token/token_col_metadata.rs
+++ b/src/tds/codec/token/token_col_metadata.rs
@@ -25,7 +25,7 @@ pub struct MetaDataColumn<'a> {
 
 impl<'a> Display for MetaDataColumn<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{} ", self.col_name)?;
+        write!(f, "[{}] ", self.col_name)?;
 
         match &self.base.ty {
             TypeInfo::FixedLen(fixed) => match fixed {

--- a/src/tds/codec/token/token_col_metadata.rs
+++ b/src/tds/codec/token/token_col_metadata.rs
@@ -25,7 +25,8 @@ pub struct MetaDataColumn<'a> {
 
 impl<'a> Display for MetaDataColumn<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "[{}] ", self.col_name)?;
+        let col_name = self.col_name.replace(']', "]]");
+        write!(f, "[{}] ", col_name)?;
 
         match &self.base.ty {
             TypeInfo::FixedLen(fixed) => match fixed {

--- a/src/tds/codec/token/token_col_metadata.rs
+++ b/src/tds/codec/token/token_col_metadata.rs
@@ -25,7 +25,8 @@ pub struct MetaDataColumn<'a> {
 
 impl<'a> Display for MetaDataColumn<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "[{}] ", self.col_name)?;
+        let name = self.col_name.replace(']', "]]");
+        write!(f, "[{}] ", name)?; 
 
         match &self.base.ty {
             TypeInfo::FixedLen(fixed) => match fixed {

--- a/src/tds/codec/token/token_col_metadata.rs
+++ b/src/tds/codec/token/token_col_metadata.rs
@@ -25,8 +25,7 @@ pub struct MetaDataColumn<'a> {
 
 impl<'a> Display for MetaDataColumn<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let name = self.col_name.replace(']', "]]");
-        write!(f, "[{}] ", name)?; 
+        write!(f, "[{}] ", self.col_name)?;
 
         match &self.base.ty {
             TypeInfo::FixedLen(fixed) => match fixed {


### PR DESCRIPTION
Changed the code to support spaces in column names in bulk insert.