### PR TITLE
Fix sign and padding in string format for negative Numeric

### DIFF
--- a/src/tds/numeric.rs
+++ b/src/tds/numeric.rs
@@ -186,9 +186,10 @@ impl Debug for Numeric {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
         write!(
             f,
-            "{}.{:0pad$}",
-            self.int_part(),
-            self.dec_part(),
+            "{}{}.{:0pad$}",
+            if self.value() < 0 { "-" } else { "" },
+            self.int_part().abs(),
+            self.dec_part().abs(),
             pad = self.scale as usize
         )
     }
@@ -366,6 +367,24 @@ mod tests {
         let n = Numeric::new_with_scale(57705, 2);
         assert_eq!(n.int_part(), 577);
         assert_eq!(n.dec_part(), 5);
+    }
+
+    #[test]
+    fn numeric_to_string() {
+        assert_eq!(Numeric::new_with_scale(123, 0).to_string(), "123.0");
+        assert_eq!(Numeric::new_with_scale(123, 1).to_string(), "12.3");
+        assert_eq!(Numeric::new_with_scale(123, 2).to_string(), "1.23");
+        assert_eq!(Numeric::new_with_scale(123, 3).to_string(), "0.123");
+        assert_eq!(Numeric::new_with_scale(123, 4).to_string(), "0.0123");
+        assert_eq!(Numeric::new_with_scale(123, 36).to_string(), "0.000000000000000000000000000000000123");
+        assert_eq!(Numeric::new_with_scale(123, 37).to_string(), "0.0000000000000000000000000000000000123");
+        assert_eq!(Numeric::new_with_scale(-123, 0).to_string(), "-123.0");
+        assert_eq!(Numeric::new_with_scale(-123, 1).to_string(), "-12.3");
+        assert_eq!(Numeric::new_with_scale(-123, 2).to_string(), "-1.23");
+        assert_eq!(Numeric::new_with_scale(-123, 3).to_string(), "-0.123");
+        assert_eq!(Numeric::new_with_scale(-123, 4).to_string(), "-0.0123");
+        assert_eq!(Numeric::new_with_scale(-123, 36).to_string(), "-0.000000000000000000000000000000000123");
+        assert_eq!(Numeric::new_with_scale(-123, 37).to_string(), "-0.0000000000000000000000000000000000123");
     }
 
     #[test]


### PR DESCRIPTION
This fixes the sign and padding problems in string format for negative `Numeric`s.

- The decimal part must not be negative when formatting to string, change to use `.abs()`.
- The integer part must have a "signed zero" when the value is negative, change to use `.abs()` and explicit sign.

I.e. before / after

- Numeric(-123, 1) was `"-12.-3"` now is `"-12.3"`
- Numeric(-123, 2) was `"-1.-23"` now is `"-1.23"`
- Numeric(-123, 3) was `"0.-123"` now is `"-0.123"`
- Numeric(-123, 4) was `"0.-123"` now is `"-0.0123"`

Fixes #368