### PR TITLE
fix: tolerate malformed UTF-16 row values

### DIFF
--- a/src/tds/codec/column_data.rs
+++ b/src/tds/codec/column_data.rs
@@ -707,7 +707,181 @@ mod tests {
     use crate::sql_read_bytes::test_utils::IntoSqlReadBytes;
     use crate::tds::Collation;
     use crate::{Error, VarLenContext};
-    use bytes::BytesMut;
+    use bytes::{BufMut, BytesMut};
+
+    async fn decode_wire(
+        ty: VarLenType,
+        len: usize,
+        collation: Option<Collation>,
+        wire: &[u8],
+    ) -> crate::Result<ColumnData<'static>> {
+        let reader = &mut BytesMut::from(wire).into_sql_read_bytes();
+        ColumnData::decode(
+            reader,
+            &TypeInfo::VarLenSized(VarLenContext::new(ty, len, collation)),
+        )
+        .await
+    }
+
+    fn short_string_wire(payload: &[u8]) -> BytesMut {
+        let mut wire = BytesMut::new();
+        wire.put_u16_le(payload.len() as u16);
+        wire.extend_from_slice(payload);
+        wire
+    }
+
+    fn ntext_wire(payload: &[u8]) -> BytesMut {
+        let mut wire = BytesMut::new();
+        wire.put_u8(1);
+        wire.put_u8(0);
+        wire.put_i32_le(0);
+        wire.put_u32_le(0);
+        wire.put_u32_le(payload.len() as u32);
+        wire.extend_from_slice(payload);
+        wire
+    }
+
+    fn decoded_string(value: ColumnData<'static>) -> Option<String> {
+        match value {
+            ColumnData::String(value) => value.map(Cow::into_owned),
+            other => panic!("expected string column data, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn nvarchar_replaces_lone_surrogates() {
+        for payload in [[0x00, 0xd8], [0x00, 0xdc]] {
+            let value = decode_wire(
+                VarLenType::NVarchar,
+                40,
+                Some(Collation::new(13632521, 52)),
+                &short_string_wire(&payload),
+            )
+            .await
+            .expect("malformed UTF-16 row values must remain readable");
+
+            assert_eq!(decoded_string(value).as_deref(), Some("\u{fffd}"));
+        }
+    }
+
+    #[tokio::test]
+    async fn nchar_replaces_lone_surrogates() {
+        for payload in [[0x00, 0xd8], [0x00, 0xdc]] {
+            let value = decode_wire(
+                VarLenType::NChar,
+                40,
+                Some(Collation::new(13632521, 52)),
+                &short_string_wire(&payload),
+            )
+            .await
+            .expect("malformed UTF-16 row values must remain readable");
+
+            assert_eq!(decoded_string(value).as_deref(), Some("\u{fffd}"));
+        }
+    }
+
+    #[tokio::test]
+    async fn ntext_replaces_lone_surrogates() {
+        for payload in [[0x00, 0xd8], [0x00, 0xdc]] {
+            let value = decode_wire(VarLenType::NText, 0, None, &ntext_wire(&payload))
+                .await
+                .expect("malformed UTF-16 row values must remain readable");
+
+            assert_eq!(decoded_string(value).as_deref(), Some("\u{fffd}"));
+        }
+    }
+
+    #[tokio::test]
+    async fn unicode_row_values_preserve_valid_text() {
+        let cases: &[(&[u8], &str)] = &[
+            (&[0x2d, 0x4e, 0x87, 0x65], "中文"),
+            (&[0x3d, 0xd8, 0x00, 0xde], "😀"),
+        ];
+
+        for (payload, expected) in cases {
+            let nvarchar = decode_wire(
+                VarLenType::NVarchar,
+                40,
+                Some(Collation::new(13632521, 52)),
+                &short_string_wire(payload),
+            )
+            .await
+            .expect("valid UTF-16 must decode");
+            let ntext = decode_wire(VarLenType::NText, 0, None, &ntext_wire(payload))
+                .await
+                .expect("valid NTEXT UTF-16 must decode");
+
+            assert_eq!(decoded_string(nvarchar).as_deref(), Some(*expected));
+            assert_eq!(decoded_string(ntext).as_deref(), Some(*expected));
+        }
+    }
+
+    #[tokio::test]
+    async fn unicode_row_values_preserve_nulls() {
+        let nvarchar = decode_wire(
+            VarLenType::NVarchar,
+            40,
+            Some(Collation::new(13632521, 52)),
+            &[0xff, 0xff],
+        )
+        .await
+        .expect("NULL nvarchar must decode");
+        let ntext = decode_wire(VarLenType::NText, 0, None, &[0])
+            .await
+            .expect("NULL ntext must decode");
+
+        assert_eq!(decoded_string(nvarchar), None);
+        assert_eq!(decoded_string(ntext), None);
+    }
+
+    #[tokio::test]
+    async fn unicode_row_values_reject_odd_byte_lengths() {
+        let nvarchar = decode_wire(
+            VarLenType::NVarchar,
+            40,
+            Some(Collation::new(13632521, 52)),
+            &short_string_wire(&[0x41, 0x00, 0x42]),
+        )
+        .await
+        .expect_err("odd nvarchar length must be a protocol error");
+        let ntext = decode_wire(VarLenType::NText, 0, None, &ntext_wire(&[0x41, 0x00, 0x42]))
+            .await
+            .expect_err("odd ntext length must be a protocol error");
+
+        assert!(matches!(nvarchar, Error::Protocol(_)));
+        assert!(matches!(ntext, Error::Protocol(_)));
+    }
+
+    #[tokio::test]
+    async fn bigvarchar_keeps_codepage_decoding() {
+        let value = decode_wire(
+            VarLenType::BigVarChar,
+            40,
+            Some(Collation::new(13632521, 52)),
+            &short_string_wire(b"plain varchar"),
+        )
+        .await
+        .expect("varchar must keep using its codepage decoder");
+
+        assert_eq!(decoded_string(value).as_deref(), Some("plain varchar"));
+    }
+
+    #[cfg(feature = "tds73")]
+    #[tokio::test]
+    async fn xml_keeps_strict_utf16_decoding() {
+        let reader = &mut short_string_wire(&[0x00, 0xd8]).into_sql_read_bytes();
+        let error = ColumnData::decode(
+            reader,
+            &TypeInfo::Xml {
+                schema: None,
+                size: 40,
+            },
+        )
+        .await
+        .expect_err("malformed XML must retain strict UTF-16 decoding");
+
+        assert!(matches!(error, Error::Utf16));
+    }
 
     async fn test_round_trip(ti: TypeInfo, d: ColumnData<'_>) {
         let mut buf = BytesMut::new();

--- a/src/tds/codec/column_data/string.rs
+++ b/src/tds/codec/column_data/string.rs
@@ -37,7 +37,11 @@ where
             }
 
             let buf: Vec<_> = buf.chunks(2).map(LittleEndian::read_u16).collect();
-            Ok(Some(String::from_utf16(&buf)?.into()))
+            let value = match ty {
+                NChar | NVarchar => String::from_utf16_lossy(&buf),
+                _ => String::from_utf16(&buf)?,
+            };
+            Ok(Some(value.into()))
         }
         _ => Ok(None),
     }

--- a/src/tds/codec/column_data/text.rs
+++ b/src/tds/codec/column_data/text.rs
@@ -38,14 +38,19 @@ where
         }
         // NTEXT
         None => {
-            let text_len = src.read_u32_le().await? as usize / 2;
+            let text_len = src.read_u32_le().await? as usize;
+            if text_len % 2 != 0 {
+                return Err(Error::Protocol("ntext: invalid length".into()));
+            }
+
+            let text_len = text_len / 2;
             let mut buf = Vec::with_capacity(text_len);
 
             for _ in 0..text_len {
                 buf.push(src.read_u16_le().await?);
             }
 
-            String::from_utf16(&buf[..])?
+            String::from_utf16_lossy(&buf[..])
         }
     };
 


### PR DESCRIPTION
## Summary

- decode `NCHAR`, `NVARCHAR`, and `NTEXT` row values lossily so unpaired UTF-16 surrogates become `U+FFFD` instead of terminating the query stream
- keep odd UTF-16 byte lengths as protocol errors, including an explicit `NTEXT` guard
- preserve strict decoding for XML and non-Unicode codepages
- add raw TDS frame regression tests covering lone surrogates, valid BMP and surrogate-pair text, nulls, and malformed lengths

## Rationale

`ColumnData::String` stores a Rust `String`, which cannot represent unpaired UTF-16 surrogate code units. The current strict conversion returns `Error::Utf16` while decoding the row, before callers can inspect or skip the affected value. Replacing only malformed surrogate sequences keeps the result stream readable without relaxing TDS framing validation.

Fixes #325

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --lib --features tds73 -- -D warnings`
- `cargo clippy --features=all`
- `cargo test --lib --features tds73` (125 passed)
- `cargo test --lib --features=all` (128 passed)
- `cargo test --lib --no-default-features` (106 passed)
