### PR TITLE
ci: make PR Code Security portable (drop prisma-org reusables)

### DIFF
--- a/.github/workflows/pr-code-security.yml
+++ b/.github/workflows/pr-code-security.yml
@@ -4,13 +4,25 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   secret-detection:
     name: Secret Detection
-    if: github.event_name == 'pull_request'
-    uses: prisma/.github/.github/workflows/secret_detection.yml@main
-    secrets: inherit
-  code-scanning:
-    name: Code Scanning
-    if: github.event_name == 'pull_request'
-    uses: prisma/.github/.github/workflows/code_scanning.yml@main
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # Full history so gitleaks can scan the whole PR range.
+          fetch-depth: 0
+          persist-credentials: false
+      - name: gitleaks
+        uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # NOTE: the previous `code-scanning` job used GitHub CodeQL, which does not
+  # support Rust — so it never scanned this crate. Rust security/quality is
+  # already covered by `cargo-deny` (advisories/bans/sources in security.yml)
+  # and the strict clippy gate, so CodeQL is intentionally omitted here.

--- a/.github/workflows/pr-code-security.yml
+++ b/.github/workflows/pr-code-security.yml
@@ -14,13 +14,27 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          # Full history so gitleaks can scan the whole PR range.
+          # Full history so gitleaks can scan every commit in the PR range.
           fetch-depth: 0
           persist-credentials: false
-      - name: gitleaks
-        uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3.0.0
+      # We run the gitleaks CLI directly rather than gitleaks-action: the
+      # action wrapper requires a paid license for repos under a GitHub
+      # organization, while the gitleaks binary itself is MIT-licensed and
+      # free. Pinned by version and verified by SHA-256 before use.
+      - name: Install gitleaks
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_VERSION: 8.30.1
+          GITLEAKS_SHA256: 551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb
+        run: |
+          set -euo pipefail
+          url="https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          curl -sSfL "$url" -o gitleaks.tar.gz
+          echo "${GITLEAKS_SHA256}  gitleaks.tar.gz" | sha256sum -c -
+          tar -xzf gitleaks.tar.gz gitleaks
+          sudo install gitleaks /usr/local/bin/gitleaks
+          gitleaks version
+      - name: Scan git history for secrets
+        run: gitleaks git --no-banner --redact --exit-code 1 .
 
   # NOTE: the previous `code-scanning` job used GitHub CodeQL, which does not
   # support Rust — so it never scanned this crate. Rust security/quality is

--- a/.github/workflows/pr-code-security.yml
+++ b/.github/workflows/pr-code-security.yml
@@ -35,8 +35,3 @@ jobs:
           gitleaks version
       - name: Scan git history for secrets
         run: gitleaks git --no-banner --redact --exit-code 1 --config .gitleaks.toml .
-
-  # NOTE: the previous `code-scanning` job used GitHub CodeQL, which does not
-  # support Rust — so it never scanned this crate. Rust security/quality is
-  # already covered by `cargo-deny` (advisories/bans/sources in security.yml)
-  # and the strict clippy gate, so CodeQL is intentionally omitted here.

--- a/.github/workflows/pr-code-security.yml
+++ b/.github/workflows/pr-code-security.yml
@@ -34,7 +34,7 @@ jobs:
           sudo install gitleaks /usr/local/bin/gitleaks
           gitleaks version
       - name: Scan git history for secrets
-        run: gitleaks git --no-banner --redact --exit-code 1 .
+        run: gitleaks git --no-banner --redact --exit-code 1 --config .gitleaks.toml .
 
   # NOTE: the previous `code-scanning` job used GitHub CodeQL, which does not
   # support Rust — so it never scanned this crate. Rust security/quality is

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,11 +1,5 @@
-# gitleaks configuration for the PR Code Security secret scan.
-#
-# Start from gitleaks' full default rule set, then allowlist only the
-# self-signed TLS material under `docker/certs/`. Those keys and
-# certificates exist solely to bring up the local SQL Server container the
-# integration tests connect to over TLS; they are throwaway test fixtures
-# (committed upstream in 2022), never production secrets. Everything else
-# in the tree and its history is still scanned.
+# gitleaks config for the PR secret scan: full default rule set, with the
+# self-signed TLS test fixtures under docker/certs/ allowlisted.
 [extend]
 useDefault = true
 

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,16 @@
+# gitleaks configuration for the PR Code Security secret scan.
+#
+# Start from gitleaks' full default rule set, then allowlist only the
+# self-signed TLS material under `docker/certs/`. Those keys and
+# certificates exist solely to bring up the local SQL Server container the
+# integration tests connect to over TLS; they are throwaway test fixtures
+# (committed upstream in 2022), never production secrets. Everything else
+# in the tree and its history is still scanned.
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Self-signed TLS test fixtures for the local integration-test SQL Server container"
+paths = [
+    '''docker/certs/.*''',
+]


### PR DESCRIPTION
## Problem

The `PR Code Security` workflow calls prisma-org reusable workflows
(`secret_detection`, `code_scanning`) with `secrets: inherit`. Those
live in the `prisma/.github` org repo and cannot be resolved from
`tiberius-rs`, so the workflow failed at **startup** on every PR to
`main` — a permanent red X unrelated to the PR's contents.

## Fix

Replace the two org reusables with a single portable secret scan:

- **Secret Detection** runs the **gitleaks CLI directly** (MIT-licensed,
  free). The `gitleaks-action` wrapper requires a *paid license* for
  repos under a GitHub organization, so it can't be used here. The
  binary is pinned to `v8.30.1` and **verified by SHA-256** before use,
  then scans the full commit history fetched by checkout.
- **`.gitleaks.toml`** keeps the entire default rule set and allowlists
  only `docker/certs/` — the self-signed TLS fixtures that bring up the
  local integration-test SQL Server container (throwaway test material
  committed upstream in 2022, not production secrets). Everything else
  in the tree and history is still scanned.
- **CodeQL code-scanning is dropped**: CodeQL has no Rust support, so
  that job never actually scanned this crate. Rust security/quality is
  already covered by `cargo-deny` (advisories/bans/sources) and the
  strict clippy gate.

All actions are SHA-pinned; `permissions` is least-privilege
(`contents: read`); checkout runs with `persist-credentials: false`.

This is a standalone CI-hygiene fix off `main` — **not** part of the
sync stack (#445) — so it can land independently and clears the last
red X on every open PR.

Please **rebase-merge**.